### PR TITLE
Fix README code block and add browser usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,35 @@ A lambda function that waits for a query string and responds with an opinionated
 
 Take the following as input:
 
-``sELECT users.`UserID`id,now(+6365)
+```sql
+sELECT users.`UserID`id,now(+6365)
 fRoM`users`
 JOIN`companies`using(`CompanyID`) WHERE`users`.`Email`='プログ\'ラマーズ>'`companies`.`NetworkID`=x'1541A488C87419F2' and`companies`.`NetworkID`=0x1541A488C87419F2
-and`companies`.`CompanyID`in(@@AdminCompanyIDs) and yeet.poop   in('') and`users`.`__Active`<>0.0 and @i := -.232 order by`users`.`__Added`desc limit 1;``
+and`companies`.`CompanyID`in(@@AdminCompanyIDs) and yeet.poop   in('') and`users`.`__Active`<>0.0 and @i := -.232 order by`users`.`__Added`desc limit 1;
+```
 
 Well that will spit back out something that looks like this
 
 ![](https://d159l1kvshziji.cloudfront.net/i/BUI3/M.png)
 
+
 As you can see, this is how *I* like to format my queries, this certainly doesn't try to format them anything remotely close to how something like MySQL Workbench likes to format them (which is awful IMO).
+
+### Browser Usage
+
+Load `pkg/mysql_format.js` and its accompanying WebAssembly module. After the
+script loads, call `wasm_bindgen().then(...)` to initialise the module and use
+`mysqlFormat()` to format your queries.
+
+```html
+<script src="pkg/mysql_format.js"></script>
+<script>
+wasm_bindgen('pkg/mysql_format_bg.wasm').then(function () {
+  const formatted = wasm_bindgen.mysqlFormat('select * from users;');
+  console.log(formatted);
+});
+</script>
+```
 
 ### Notes
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -6,16 +6,35 @@ A lambda function that waits for a query string and responds with an opinionated
 
 Take the following as input:
 
-``sELECT users.`UserID`id,now(+6365)
+```sql
+sELECT users.`UserID`id,now(+6365)
 fRoM`users`
 JOIN`companies`using(`CompanyID`) WHERE`users`.`Email`='プログ\'ラマーズ>'`companies`.`NetworkID`=x'1541A488C87419F2' and`companies`.`NetworkID`=0x1541A488C87419F2
-and`companies`.`CompanyID`in(@@AdminCompanyIDs) and yeet.poop   in('') and`users`.`__Active`<>0.0 and @i := -.232 order by`users`.`__Added`desc limit 1;``
+and`companies`.`CompanyID`in(@@AdminCompanyIDs) and yeet.poop   in('') and`users`.`__Active`<>0.0 and @i := -.232 order by`users`.`__Added`desc limit 1;
+```
 
 Well that will spit back out something that looks like this
 
 ![](https://d159l1kvshziji.cloudfront.net/i/BUI3/M.png)
 
+
 As you can see, this is how *I* like to format my queries, this certainly doesn't try to format them anything remotely close to how something like MySQL Workbench likes to format them (which is awful IMO).
+
+### Browser Usage
+
+Load `pkg/mysql_format.js` and its accompanying WebAssembly module. After the
+script loads, call `wasm_bindgen().then(...)` to initialise the module and use
+`mysqlFormat()` to format your queries.
+
+```html
+<script src="pkg/mysql_format.js"></script>
+<script>
+wasm_bindgen('pkg/mysql_format_bg.wasm').then(function () {
+  const formatted = wasm_bindgen.mysqlFormat('select * from users;');
+  console.log(formatted);
+});
+</script>
+```
 
 ### Notes
 


### PR DESCRIPTION
## Summary
- fix unclosed code block in README
- explain how to initialise the WASM module in the browser
- keep pkg/README in sync

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa1e2a7a0832fbd81f0b600d4c35e