### PR TITLE
Add test for users query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,4 +723,13 @@ mod tests {
         let formatted = mysqlFormat("select 1;");
         assert_eq!(formatted, "<b style=\"color:#2962FF\">select</b> <span style=\"color:#b71c1c\">1</span><b>;</b>");
     }
+
+    #[test]
+    fn test_mysql_format_select_users() {
+        let formatted = mysqlFormat("select * from users;");
+        assert_eq!(
+            formatted,
+            "<b style=\"color:#2962FF\">select</b><b>*</b><b style=\"color:#2962FF\">\nfrom</b><span style=\"color:#674818\">`users`</span><b>;</b>"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add a unit test covering `mysqlFormat` on `select * from users;`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_683fa7cf5400832fa94db9882e2fa969